### PR TITLE
chore: Use `import.meta.env.VITE_*`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # https://hasura.io/docs/1.0/graphql/core/guides/integrations/auth0-jwt.html
 
 VITE_AUTH0_CLIENT="YOURAUTHZEROAPPCLIENTID"
-VITE_AUTH0_DOMAIN="your.example.com"
+VITE_AUTH0_DOMAIN="your-auth0-account.auth0.com"
 
 # If deploying to DigitalOcean:
-# ... also add them to the App's Environment Variables component.
+# ... also add them to the App's Environment Variables component settings.

--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,3 @@
-# TODO: Figure out why VITE isn't finding 'normal' env-vars without dotenv-load.
-VITE_AUTH0_DOMAIN="battle.orb.zone"
+# Used by the `dev` task in package.json for env-vars through dotenv-load.
+VITE_AUTH0_DOMAIN="orbz.auth0.com"
 VITE_AUTH0_CLIENT="NH9H4hxCHSDWbRLXIqR4aq7dkmAhsqS4"

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Following setup instructions from the following resources:
 ## Things I learned along the way...
 
 - Using Vite as the build-tool, requires that if you want to use environment variables in your code, you must do a couple things.  First, they *must* be prefixed with `VITE_` and if using TypeScript, you need to update `./src/react-app-env.d.ts` to declare the ones you need, so that the production build doesn't fail with: **_"... does not exist on type 'ProcessEnv'."_**
-- 
+- I ended up adding the build-config ENV vars into the `.env.local` file included in the git repo, and learned VITE allows `import.meta.env.VITE_*` through the build output. _(...and './src/react-app-env.d.ts' needed an updated interface for `ImportMeta`.)

--- a/package.json
+++ b/package.json
@@ -2,11 +2,8 @@
   "name": "battle-orb",
   "version": "0.0.1",
   "scripts": {
-    "with:env": "VITE_TEST_VAR=${VITE_TEST_VAR:=MISSING_TEST_VAR}",
-    "predev:alt": "echo $VITE_TEST_VAR",
-    "dev": "vite",
-    "dev:alt": "npm run with:env && vite",
-    "build": "dotenv-load tsc && dotenv-load vite build",
+    "dev": "dotenv-load vite",
+    "build": "tsc && vite build",
     "gen:gql": "graphql-codegen --config codegen.yml"
   },
   "dependencies": {

--- a/src/authClient.ts
+++ b/src/authClient.ts
@@ -1,6 +1,6 @@
 import createAuth0Client from '@auth0/auth0-spa-js';
 
 export default createAuth0Client({
-  client_id: process.env.VITE_AUTH0_CLIENT,
-  domain: process.env.VITE_AUTH0_DOMAIN,
+  client_id: import.meta.env.VITE_AUTH0_CLIENT,
+  domain: import.meta.env.VITE_AUTH0_DOMAIN,
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,8 +11,6 @@ const checkAuth = async () => {
 
 checkAuth();
 
-console.log("who loves me?", process.env.VITE_TEST_VAR);
-
 ReactDOM.render(
   <React.StrictMode>
     <AuLayout title={`battle.orb.zone`} year={2020}>

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -2,6 +2,13 @@
 /// <reference types="react" />
 /// <reference types="react-dom" />
 
+interface ImportMeta {
+  env: {
+    readonly VITE_AUTH0_CLIENT: string;
+    readonly VITE_AUTH0_DOMAIN: string;
+  };
+}
+
 declare namespace NodeJS {
   interface Process{
     env: ProcessEnv
@@ -17,9 +24,6 @@ declare namespace NodeJS {
      * 
      */
     readonly NODE_ENV: 'development' | 'production'
-    readonly VITE_AUTH0_CLIENT: string;
-    readonly VITE_AUTH0_DOMAIN: string;
-    readonly VITE_TEST_VAR: string;
   }
 }
 


### PR DESCRIPTION
... for `vite build` task to pick up DigitalOcean env-vars.