### PR TITLE
fix: DigitalOcean build ENV vars workaround... maybe?

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,6 @@ VITE_AUTH0_CLIENT="YOURAUTHZEROAPPCLIENTID"
 VITE_AUTH0_DOMAIN="your-auth0-account.auth0.com"
 VITE_AUTH0_REDIRECT_URI="http://localhost:3000/"
 
-# If deploying to DigitalOcean:
-# ... also add them to the App's Environment Variables component settings.
+# If deploying to DigitalOcean, you can copy and modify this to: .env.production 
+# ... or add them to the App's Environment Variables component settings.
+# ... I chose to exclude the VITE_ prefix from the Build Pipeline's ENV vars.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "dotenv-load vite",
-    "build": "tsc && vite build",
-    "gen:gql": "graphql-codegen --config codegen.yml"
+    "build": "npm run with:env && tsc && vite build",
+    "gen:gql": "graphql-codegen --config codegen.yml",
+    "with:env": "VITE_AUTH0_CLIENT=${AUTH0_CLIENT:=MISSING_CLIENT} VITE_AUTH0_DOMAIN=${AUTH0_DOMAIN:=MISSING_DOMAIN} VITE_AUTH0_REDIRECT_URI=${AUTH0_REDIRECT_URI:=MISSING_REDIRECT_URI} "
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.12.1",


### PR DESCRIPTION
Attempting to populate environment variables through build pipeline, avoiding the need for: `.env.production`